### PR TITLE
set `coveralls` as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/jest": "^23.3.1",
     "@types/lodash": "^4.14.113",
     "@types/node": "^10.5.3",
+    "coveralls": "^3.0.2",
     "husky": "^0.14.3",
     "jest": "^23.4.2",
     "lint-staged": "^7.2.0",
@@ -26,7 +27,6 @@
     "typescript": "^2.9.2"
   },
   "dependencies": {
-    "coveralls": "^3.0.2",
     "expression-eval": "^1.3.0",
     "ip": "^1.1.5",
     "lodash": "^4.17.10"


### PR DESCRIPTION
to descrease the overall package size considerably.

before
```
"coveralls": "^3.0.2",
"expression-eval": "^1.3.0",
"ip": "^1.1.5",
"lodash": "^4.17.10"

7,294,430 bytes (13.1 MB on disk) for 1,964 items
```

after
```
"expression-eval": "^1.3.0",
"ip": "^1.1.5",
"lodash": "^4.17.10"

2,167,864 bytes (6 MB on disk) for 1,106 items
```

the next step is to use the modularized lodash methods which will bring the package size to around 1MB