### PR TITLE
improvement: convert all management_api to async function

### DIFF
--- a/src/managementEnforcer.ts
+++ b/src/managementEnforcer.ts
@@ -25,7 +25,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *         0-index elements of "p" policy rules. So make sure your subject
    *         is the 0-index element, like (sub, obj, act). Duplicates are removed.
    */
-  public getAllSubjects(): string[] {
+  public async getAllSubjects(): Promise<string[]> {
     return this.getAllNamedSubjects('p');
   }
 
@@ -38,7 +38,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *         your subject is the 0-index element, like (sub, obj, act).
    *         Duplicates are removed.
    */
-  public getAllNamedSubjects(ptype: string): string[] {
+  public async getAllNamedSubjects(ptype: string): Promise<string[]> {
     return this.model.getValuesForFieldInPolicy('p', ptype, 0);
   }
 
@@ -50,7 +50,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *         is the 1-index element, like (sub, obj, act).
    *         Duplicates are removed.
    */
-  public getAllObjects(): string[] {
+  public async getAllObjects(): Promise<string[]> {
     return this.getAllNamedObjects('p');
   }
 
@@ -63,7 +63,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *         your object is the 1-index element, like (sub, obj, act).
    *         Duplicates are removed.
    */
-  public getAllNamedObjects(ptype: string): string[] {
+  public async getAllNamedObjects(ptype: string): Promise<string[]> {
     return this.model.getValuesForFieldInPolicy('p', ptype, 1);
   }
 
@@ -75,7 +75,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *         is the 2-index element, like (sub, obj, act).
    *         Duplicates are removed.
    */
-  public getAllActions(): string[] {
+  public async getAllActions(): Promise<string[]> {
     return this.getAllNamedActions('p');
   }
 
@@ -88,7 +88,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *         your action is the 2-index element, like (sub, obj, act).
    *         Duplicates are removed.
    */
-  public getAllNamedActions(ptype: string): string[] {
+  public async getAllNamedActions(ptype: string): Promise<string[]> {
     return this.model.getValuesForFieldInPolicy('p', ptype, 2);
   }
 
@@ -100,7 +100,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *         role is the 1-index element, like (sub, role).
    *         Duplicates are removed.
    */
-  public getAllRoles(): string[] {
+  public async getAllRoles(): Promise<string[]> {
     return this.getAllNamedRoles('g');
   }
 
@@ -113,7 +113,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *         sure your subject is the 0-index element, like (sub, obj, act).
    *         Duplicates are removed.
    */
-  public getAllNamedRoles(ptype: string): string[] {
+  public async getAllNamedRoles(ptype: string): Promise<string[]> {
     return this.model.getValuesForFieldInPolicy('g', ptype, 1);
   }
 
@@ -122,7 +122,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *
    * @return all the "p" policy rules.
    */
-  public getPolicy(): string[][] {
+  public async getPolicy(): Promise<string[][]> {
     return this.getNamedPolicy('p');
   }
 
@@ -134,7 +134,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *                    means not to match this field.
    * @return the filtered "p" policy rules.
    */
-  public getFilteredPolicy(fieldIndex: number, ...fieldValues: string[]): string[][] {
+  public async getFilteredPolicy(fieldIndex: number, ...fieldValues: string[]): Promise<string[][]> {
     return this.getFilteredNamedPolicy('p', fieldIndex, ...fieldValues);
   }
 
@@ -144,7 +144,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @param ptype the policy type, can be "p", "p2", "p3", ..
    * @return the "p" policy rules of the specified ptype.
    */
-  public getNamedPolicy(ptype: string): string[][] {
+  public async getNamedPolicy(ptype: string): Promise<string[][]> {
     return this.model.getPolicy('p', ptype);
   }
 
@@ -157,7 +157,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *                    means not to match this field.
    * @return the filtered "p" policy rules of the specified ptype.
    */
-  public getFilteredNamedPolicy(ptype: string, fieldIndex: number, ...fieldValues: string[]): string[][] {
+  public async getFilteredNamedPolicy(ptype: string, fieldIndex: number, ...fieldValues: string[]): Promise<string[][]> {
     return this.model.getFilteredPolicy('p', ptype, fieldIndex, ...fieldValues);
   }
 
@@ -166,7 +166,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *
    * @return all the "g" policy rules.
    */
-  public getGroupingPolicy(): string[][] {
+  public async getGroupingPolicy(): Promise<string[][]> {
     return this.getNamedGroupingPolicy('g');
   }
 
@@ -177,7 +177,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @param fieldValues the field values to be matched, value "" means not to match this field.
    * @return the filtered "g" policy rules.
    */
-  public getFilteredGroupingPolicy(fieldIndex: number, ...fieldValues: string[]): string[][] {
+  public async getFilteredGroupingPolicy(fieldIndex: number, ...fieldValues: string[]): Promise<string[][]> {
     return this.getFilteredNamedGroupingPolicy('g', fieldIndex, ...fieldValues);
   }
 
@@ -187,7 +187,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @param ptype the policy type, can be "g", "g2", "g3", ..
    * @return the "g" policy rules of the specified ptype.
    */
-  public getNamedGroupingPolicy(ptype: string): string[][] {
+  public async getNamedGroupingPolicy(ptype: string): Promise<string[][]> {
     return this.model.getPolicy('g', ptype);
   }
 
@@ -200,7 +200,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *                    means not to match this field.
    * @return the filtered "g" policy rules of the specified ptype.
    */
-  public getFilteredNamedGroupingPolicy(ptype: string, fieldIndex: number, ...fieldValues: string[]): string[][] {
+  public async getFilteredNamedGroupingPolicy(ptype: string, fieldIndex: number, ...fieldValues: string[]): Promise<string[][]> {
     return this.model.getFilteredPolicy('g', ptype, fieldIndex, ...fieldValues);
   }
 
@@ -210,7 +210,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @param params the "p" policy rule, ptype "p" is implicitly used.
    * @return whether the rule exists.
    */
-  public hasPolicy(...params: string[]): boolean {
+  public async hasPolicy(...params: string[]): Promise<boolean> {
     return this.hasNamedPolicy('p', ...params);
   }
 
@@ -221,7 +221,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @param params the "p" policy rule.
    * @return whether the rule exists.
    */
-  public hasNamedPolicy(ptype: string, ...params: string[]): boolean {
+  public async hasNamedPolicy(ptype: string, ...params: string[]): Promise<boolean> {
     return this.model.hasPolicy('p', ptype, params);
   }
 
@@ -247,7 +247,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async addNamedPolicy(ptype: string, ...params: string[]): Promise<boolean> {
-    return await this.addPolicyInternal('p', ptype, params);
+    return this.addPolicyInternal('p', ptype, params);
   }
 
   /**
@@ -257,7 +257,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async removePolicy(...params: string[]): Promise<boolean> {
-    return await this.removeNamedPolicy('p', ...params);
+    return this.removeNamedPolicy('p', ...params);
   }
 
   /**
@@ -269,7 +269,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async removeFilteredPolicy(fieldIndex: number, ...fieldValues: string[]): Promise<boolean> {
-    return await this.removeFilteredNamedPolicy('p', fieldIndex, ...fieldValues);
+    return this.removeFilteredNamedPolicy('p', fieldIndex, ...fieldValues);
   }
 
   /**
@@ -280,7 +280,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async removeNamedPolicy(ptype: string, ...params: string[]): Promise<boolean> {
-    return await this.removePolicyInternal('p', ptype, params);
+    return this.removePolicyInternal('p', ptype, params);
   }
 
   /**
@@ -293,7 +293,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async removeFilteredNamedPolicy(ptype: string, fieldIndex: number, ...fieldValues: string[]): Promise<boolean> {
-    return await this.removeFilteredPolicyInternal('p', ptype, fieldIndex, fieldValues);
+    return this.removeFilteredPolicyInternal('p', ptype, fieldIndex, fieldValues);
   }
 
   /**
@@ -302,7 +302,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @param params the "g" policy rule, ptype "g" is implicitly used.
    * @return whether the rule exists.
    */
-  public hasGroupingPolicy(...params: string[]): boolean {
+  public async hasGroupingPolicy(...params: string[]): Promise<boolean> {
     return this.hasNamedGroupingPolicy('g', ...params);
   }
 
@@ -313,7 +313,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @param params the "g" policy rule.
    * @return whether the rule exists.
    */
-  public hasNamedGroupingPolicy(ptype: string, ...params: string[]): boolean {
+  public async hasNamedGroupingPolicy(ptype: string, ...params: string[]): Promise<boolean> {
     return this.model.hasPolicy('g', ptype, params);
   }
 
@@ -326,7 +326,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async addGroupingPolicy(...params: string[]): Promise<boolean> {
-    return await this.addNamedGroupingPolicy('g', ...params);
+    return this.addNamedGroupingPolicy('g', ...params);
   }
 
   /**
@@ -355,7 +355,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async removeGroupingPolicy(...params: string[]): Promise<boolean> {
-    return await this.removeNamedGroupingPolicy('g', ...params);
+    return this.removeNamedGroupingPolicy('g', ...params);
   }
 
   /**
@@ -367,7 +367,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async removeFilteredGroupingPolicy(fieldIndex: number, ...fieldValues: string[]): Promise<boolean> {
-    return await this.removeFilteredNamedGroupingPolicy('g', fieldIndex, ...fieldValues);
+    return this.removeFilteredNamedGroupingPolicy('g', fieldIndex, ...fieldValues);
   }
 
   /**
@@ -383,6 +383,7 @@ export class ManagementEnforcer extends InternalEnforcer {
     if (this.autoBuildRoleLinks) {
       await this.buildRoleLinks();
     }
+
     return ruleRemoved;
   }
 
@@ -397,9 +398,11 @@ export class ManagementEnforcer extends InternalEnforcer {
    */
   public async removeFilteredNamedGroupingPolicy(ptype: string, fieldIndex: number, ...fieldValues: string[]): Promise<boolean> {
     const ruleRemoved = await this.removeFilteredPolicyInternal('g', ptype, fieldIndex, fieldValues);
+
     if (this.autoBuildRoleLinks) {
       await this.buildRoleLinks();
     }
+
     return ruleRemoved;
   }
 
@@ -408,7 +411,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @param name custom function name
    * @param func function
    */
-  public addFunction(name: string, func: any): void {
+  public async addFunction(name: string, func: any): Promise<void> {
     this.fm.addFunction(name, func);
   }
 }

--- a/test/enforcer.test.ts
+++ b/test/enforcer.test.ts
@@ -20,8 +20,8 @@ async function testEnforce(e: Enforcer, sub: string, obj: string, act: string, r
   await expect(e.enforce(sub, obj, act)).resolves.toBe(res);
 }
 
-function testGetPolicy(e: Enforcer, res: string[][]): void {
-  const myRes = e.getPolicy();
+async function testGetPolicy(e: Enforcer, res: string[][]): Promise<void> {
+  const myRes = await e.getPolicy();
   console.log('Policy: ', myRes);
 
   expect(Util.array2DEquals(res, myRes)).toBe(true);
@@ -208,7 +208,7 @@ test('TestReloadPolicy', async () => {
   const e = await newEnforcer('examples/rbac_model.conf', 'examples/rbac_policy.csv');
 
   await e.loadPolicy();
-  testGetPolicy(e, [
+  await testGetPolicy(e, [
     ['alice', 'data1', 'read'],
     ['bob', 'data2', 'write'],
     ['data2_admin', 'data2', 'read'],

--- a/test/managementAPI.test.ts
+++ b/test/managementAPI.test.ts
@@ -29,53 +29,53 @@ function testArray2DEquals(value: string[][], other: string[][]): void {
 }
 
 test('getAllSubjects', async () => {
-  const allSubjects = e.getAllSubjects();
+  const allSubjects = await e.getAllSubjects();
   expect(Util.arrayEquals(allSubjects, ['alice', 'bob', 'data2_admin']));
 });
 
 test('getAllNamedSubjects', async () => {
-  const allNamedSubjects = e.getAllNamedSubjects('p');
+  const allNamedSubjects = await e.getAllNamedSubjects('p');
   expect(Util.arrayEquals(allNamedSubjects, ['alice', 'bob', 'data2_admin']));
 });
 
 test('getAllObjects', async () => {
-  const allObjects = e.getAllObjects();
+  const allObjects = await e.getAllObjects();
   testArrayEquals(allObjects, ['data1', 'data2']);
 });
 
 test('getAllNamedObjects', async () => {
-  let allNamedObjects = e.getAllNamedObjects('p');
+  let allNamedObjects = await e.getAllNamedObjects('p');
   testArrayEquals(allNamedObjects, ['data1', 'data2']);
-  allNamedObjects = e.getAllNamedObjects('p1');
+  allNamedObjects = await e.getAllNamedObjects('p1');
   testArrayEquals(allNamedObjects, []);
 });
 
 test('getAllActions', async () => {
-  const allActions = e.getAllActions();
+  const allActions = await e.getAllActions();
   testArrayEquals(allActions, ['read', 'write']);
 });
 
 test('getAllNamedActions', async () => {
-  let allNamedActions = e.getAllNamedActions('p');
+  let allNamedActions = await e.getAllNamedActions('p');
   testArrayEquals(allNamedActions, ['read', 'write']);
-  allNamedActions = e.getAllNamedActions('p1');
+  allNamedActions = await e.getAllNamedActions('p1');
   testArrayEquals(allNamedActions, []);
 });
 
 test('getAllRoles', async () => {
-  const allRoles = e.getAllRoles();
+  const allRoles = await e.getAllRoles();
   testArrayEquals(allRoles, ['data2_admin']);
 });
 
 test('getAllNamedRoles', async () => {
-  let allNamedRoles = e.getAllNamedRoles('g');
+  let allNamedRoles = await e.getAllNamedRoles('g');
   testArrayEquals(allNamedRoles, ['data2_admin']);
-  allNamedRoles = e.getAllNamedRoles('g1');
+  allNamedRoles = await e.getAllNamedRoles('g1');
   testArrayEquals(allNamedRoles, []);
 });
 
 test('getPolicy', async () => {
-  const policy = e.getPolicy();
+  const policy = await e.getPolicy();
   testArray2DEquals(policy, [
     ['alice', 'data1', 'read'],
     ['bob', 'data2', 'write'],
@@ -85,56 +85,56 @@ test('getPolicy', async () => {
 });
 
 test('getFilteredPolicy', async () => {
-  let filteredPolicy = e.getFilteredPolicy(0, 'alice');
+  let filteredPolicy = await e.getFilteredPolicy(0, 'alice');
   testArray2DEquals(filteredPolicy, [['alice', 'data1', 'read']]);
-  filteredPolicy = e.getFilteredPolicy(0, 'bob');
+  filteredPolicy = await e.getFilteredPolicy(0, 'bob');
   testArray2DEquals(filteredPolicy, [['bob', 'data2', 'write']]);
 });
 
 test('getNamedPolicy', async () => {
-  let namedPolicy = e.getNamedPolicy('p');
+  let namedPolicy = await e.getNamedPolicy('p');
   testArray2DEquals(namedPolicy, [
     ['alice', 'data1', 'read'],
     ['bob', 'data2', 'write'],
     ['data2_admin', 'data2', 'read'],
     ['data2_admin', 'data2', 'write']
   ]);
-  namedPolicy = e.getNamedPolicy('p1');
+  namedPolicy = await e.getNamedPolicy('p1');
   testArray2DEquals(namedPolicy, []);
 });
 
 test('getFilteredNamedPolicy', async () => {
-  const filteredNamedPolicy = e.getFilteredNamedPolicy('p', 0, 'bob');
+  const filteredNamedPolicy = await e.getFilteredNamedPolicy('p', 0, 'bob');
   testArray2DEquals(filteredNamedPolicy, [['bob', 'data2', 'write']]);
 });
 
 test('getGroupingPolicy', async () => {
-  const groupingPolicy = e.getGroupingPolicy();
+  const groupingPolicy = await e.getGroupingPolicy();
   testArray2DEquals(groupingPolicy, [['alice', 'data2_admin']]);
 });
 
 test('getFilteredGroupingPolicy', async () => {
-  const filteredGroupingPolicy = e.getFilteredGroupingPolicy(0, 'alice');
+  const filteredGroupingPolicy = await e.getFilteredGroupingPolicy(0, 'alice');
   testArray2DEquals(filteredGroupingPolicy, [['alice', 'data2_admin']]);
 });
 
 test('getNamedGroupingPolicy', async () => {
-  const namedGroupingPolicy = e.getNamedGroupingPolicy('g');
+  const namedGroupingPolicy = await e.getNamedGroupingPolicy('g');
   testArray2DEquals(namedGroupingPolicy, [['alice', 'data2_admin']]);
 });
 
 test('getFilteredNamedGroupingPolicy', async () => {
-  const namedGroupingPolicy = e.getFilteredNamedGroupingPolicy('g', 0, 'alice');
+  const namedGroupingPolicy = await e.getFilteredNamedGroupingPolicy('g', 0, 'alice');
   testArray2DEquals(namedGroupingPolicy, [['alice', 'data2_admin']]);
 });
 
 test('hasPolicy', async () => {
-  const hasPolicy = e.hasPolicy('data2_admin', 'data2', 'read');
+  const hasPolicy = await e.hasPolicy('data2_admin', 'data2', 'read');
   expect(hasPolicy).toBe(true);
 });
 
 test('hasNamedPolicy', async () => {
-  const hasNamedPolicy = e.hasNamedPolicy('p', 'data2_admin', 'data2', 'read');
+  const hasNamedPolicy = await e.hasNamedPolicy('p', 'data2_admin', 'data2', 'read');
   expect(hasNamedPolicy).toBe(true);
 });
 
@@ -142,51 +142,51 @@ test('addPolicy', async () => {
   const p = ['eve', 'data3', 'read'];
   const added = await e.addPolicy(...p);
   expect(added).toBe(true);
-  expect(e.hasPolicy(...p)).toBe(true);
+  expect(await e.hasPolicy(...p)).toBe(true);
 });
 
 test('addNamedPolicy', async () => {
   const p = ['eve', 'data3', 'read'];
   const added = await e.addNamedPolicy('p', ...p);
   expect(added).toBe(true);
-  expect(e.hasPolicy(...p)).toBe(true);
+  expect(await e.hasPolicy(...p)).toBe(true);
 });
 
 test('removePolicy', async () => {
   const p = ['alice', 'data1', 'read'];
   const removed = await e.removePolicy(...p);
   expect(removed).toBe(true);
-  expect(e.hasPolicy(...p)).toBe(false);
+  expect(await e.hasPolicy(...p)).toBe(false);
 });
 
 test('removeFilteredPolicy', async () => {
   const p = ['alice', 'data1', 'read'];
   const removed = await e.removeFilteredPolicy(0, ...p);
   expect(removed).toBe(true);
-  expect(e.hasPolicy(...p)).toBe(false);
+  expect(await e.hasPolicy(...p)).toBe(false);
 });
 
 test('removeNamedPolicy', async () => {
   const p = ['alice', 'data1', 'read'];
   const removed = await e.removeNamedPolicy('p', ...p);
   expect(removed).toBe(true);
-  expect(e.hasPolicy(...p)).toBe(false);
+  expect(await e.hasPolicy(...p)).toBe(false);
 });
 
 test('removeFilteredNamedPolicy', async () => {
   const p = ['alice', 'data1', 'read'];
   const removed = await e.removeFilteredNamedPolicy('p', 0, ...p);
   expect(removed).toBe(true);
-  expect(e.hasPolicy(...p)).toBe(false);
+  expect(await e.hasPolicy(...p)).toBe(false);
 });
 
 test('hasGroupingPolicy', async () => {
-  const has = e.hasGroupingPolicy('alice', 'data2_admin');
+  const has = await e.hasGroupingPolicy('alice', 'data2_admin');
   expect(has).toBe(true);
 });
 
 test('hasNamedGroupingPolicy', async () => {
-  const has = e.hasNamedGroupingPolicy('g', 'alice', 'data2_admin');
+  const has = await e.hasNamedGroupingPolicy('g', 'alice', 'data2_admin');
   expect(has).toBe(true);
 });
 


### PR DESCRIPTION
BREAKING CHANGE: 

There are affected function:

- `getPermissionsForUser()` 
- `hasPermissionForUser()` 
- `getAllSubjects()`
- `getAllNamedSubjects()`
- `getAllObjects()`
- `getAllNamedObjects()`
- `getAllActions()`
- `getAllNamedActions()`
- `getAllRoles()`
- `getAllNamedRoles()`
- `getPolicy()`
- `getFilteredPolicy()`
- `getNamedPolicy()`
- `getFilteredNamedPolicy()`
- `getGroupingPolicy()`
- `getFilteredGroupingPolicy()`
- `getNamedGroupingPolicy()`
- `getFilteredNamedGroupingPolicy()`
- `hasPolicy()`
- `hasNamedPolicy()`
- `hasGroupingPolicy()`
- `hasNamedGroupingPolicy()`
- `addFunction()`
