### PR TITLE
fix(rbac): fix defaultManager hasRole method

### DIFF
--- a/src/rbac/defaultRoleManager.ts
+++ b/src/rbac/defaultRoleManager.ts
@@ -99,7 +99,7 @@ class Roles extends Map<string, Role> {
     } else {
       return this.has(name);
     }
-    return true;
+    return ok;
   }
 
   public createRole(name: string, matchingFunc?: MatchingFunc): Role {


### PR DESCRIPTION
In the current version hasRole method of the defaultRoleManager always returns true if matchingFunc
is provided, now it returns true only when it is supposed to.