### PR TITLE
fix(rbac): fix defaultRoleManager hasRole method

### DIFF
--- a/src/rbac/defaultRoleManager.ts
+++ b/src/rbac/defaultRoleManager.ts
@@ -99,7 +99,7 @@ class Roles extends Map<string, Role> {
     } else {
       return this.has(name);
     }
-    return true;
+    return ok;
   }
 
   public createRole(name: string, matchingFunc?: MatchingFunc): Role {


### PR DESCRIPTION
In the current version, defaultRoleManager hasRole always returns true if a matchingFunc is provided. This PR fixes it.

Signed-off-by: Alexey Yunoshev <alexey.yunoshev@gmail.com>