### PR TITLE
feat: use new license format

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,12 +64,7 @@
     "type": "git",
     "url": "https://github.com/casbin/node-casbin.git"
   },
-  "licenses": [
-    {
-      "type": "Apache-2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0"
-    }
-  ],
+  "license": "Apache-2.0",
   "husky": {
     "hooks": {
       "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true",


### PR DESCRIPTION
As for now, `node-casbin` use an outdated `package.json` field `licenses`. And npmjs.com cannot recognize it.

![image](https://user-images.githubusercontent.com/31370133/126185203-7b5440f7-e242-441c-be78-f98efcdb686d.png)

New SPDX format can resolve this problem.

Signed-off-by: Zxilly <zhouxinyu1001@gmail.com>