### PR TITLE
fix(replaceeval): add third param to replaceEval and only replace eval() w/ matching ruleName

### DIFF
--- a/src/coreEnforcer.ts
+++ b/src/coreEnforcer.ts
@@ -434,7 +434,7 @@ export class CoreEnforcer {
           for (const ruleName of ruleNames) {
             if (ruleName in parameters) {
               const rule = escapeAssertion(parameters[ruleName]);
-              expWithRule = replaceEval(expWithRule, rule);
+              expWithRule = replaceEval(expWithRule, ruleName, rule);
             } else {
               throw new Error(`${ruleName} not in ${parameters}`);
             }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -112,8 +112,8 @@ function hasEval(s: string): boolean {
 }
 
 // replaceEval replace function eval with the value of its parameters
-function replaceEval(s: string, rule: string): string {
-  return s.replace(evalReg, '(' + rule + ')');
+function replaceEval(s: string, ruleName: string, rule: string): string {
+  return s.replace(`eval(${ruleName})`, '(' + rule + ')');
 }
 
 // getEvalValue returns the parameters of function eval

--- a/test/enforcer.test.ts
+++ b/test/enforcer.test.ts
@@ -579,6 +579,25 @@ test('test ABAC Scaling', async () => {
   await testEnforce(e, sub3, '/data2', 'write', false);
 });
 
+test('test ABAC multiple eval()', async () => {
+  const m = newModel();
+  m.addDef('r', 'r', 'sub, obj, act');
+  m.addDef('p', 'p', 'sub_rule_1, sub_rule_2, act');
+  m.addDef('e', 'e', 'some(where (p.eft == allow))');
+  m.addDef('m', 'm', 'eval(p.sub_rule_1) && eval(p.sub_rule_2) && r.act == p.act');
+
+  const policy = new StringAdapter(
+    `
+    p, r.sub > 50, r.obj > 50, read
+    `
+  );
+
+  const e = await newEnforcer(m, policy);
+  await testEnforce(e, 56, (98 as unknown) as string, 'read', true);
+  await testEnforce(e, 23, (67 as unknown) as string, 'read', false);
+  await testEnforce(e, 78, (34 as unknown) as string, 'read', false);
+});
+
 test('TestEnforceSync', async () => {
   const m = newModel();
   m.addDef('r', 'r', 'sub, obj, act');

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -158,8 +158,12 @@ test('test hasEval', () => {
 });
 
 test('test replaceEval', () => {
-  expect(util.replaceEval('eval() && a && b && c', 'a')).toEqual('(a) && a && b && c');
-  expect(util.replaceEval('eval() && a && b && c', '(a)')).toEqual('((a)) && a && b && c');
+  expect(util.replaceEval('eval() && a && b && c', '', 'a')).toEqual('(a) && a && b && c');
+  expect(util.replaceEval('eval() && a && b && c', '', '(a)')).toEqual('((a)) && a && b && c');
+  expect(util.replaceEval('eval(p_some_rule) && c', 'p_some_rule', '(a)')).toEqual('((a)) && c');
+  expect(util.replaceEval('eval(p_some_rule) && eval(p_some_other_rule) && c', 'p_some_rule', '(a)')).toEqual(
+    '((a)) && eval(p_some_other_rule) && c'
+  );
 });
 
 test('test getEvalValue', () => {


### PR DESCRIPTION
This fixes https://github.com/casbin/node-casbin/issues/315.

I chose to go with a slightly more straightforward approach than what was done in https://github.com/casbin/casbin/pull/620; however, this meant modifying an existing util function instead of creating a new one.