### PR TITLE
fix: fix error overloading for role manager

### DIFF
--- a/src/coreEnforcer.ts
+++ b/src/coreEnforcer.ts
@@ -48,7 +48,7 @@ export class CoreEnforcer {
 
   protected adapter: UpdatableAdapter | FilteredAdapter | Adapter | BatchAdapter;
   protected watcher: Watcher | null = null;
-  protected rmMap: Map<string, RoleManager> = new Map<string, RoleManager>([['g', new DefaultRoleManager(10)]]);
+  protected rmMap: Map<string, RoleManager>;
 
   protected enabled = true;
   protected autoSave = true;
@@ -198,8 +198,6 @@ export class CoreEnforcer {
 
     this.sortPolicies();
 
-    this.initRmMap();
-
     if (this.autoBuildRoleLinks) {
       await this.buildRoleLinksInternal();
     }
@@ -231,8 +229,6 @@ export class CoreEnforcer {
     }
 
     this.sortPolicies();
-
-    this.initRmMap();
 
     if (this.autoBuildRoleLinks) {
       await this.buildRoleLinksInternal();

--- a/src/enforcer.ts
+++ b/src/enforcer.ts
@@ -71,6 +71,8 @@ export class Enforcer extends ManagementEnforcer {
     this.model = m;
     this.model.printModel();
 
+    this.initRmMap();
+
     if (!lazyLoad && this.adapter) {
       await this.loadPolicy();
     }

--- a/test/rbac/defaultRoleManager.test.ts
+++ b/test/rbac/defaultRoleManager.test.ts
@@ -1,4 +1,4 @@
-import { DefaultRoleManager } from '../../src/rbac';
+import { DefaultRoleManager } from '../../src';
 import { keyMatch2Func } from '../../src/util';
 
 test('TestAllMatchingFunc', async () => {


### PR DESCRIPTION
this bug affects v5.5.0 to v5.11.4, it will reload role manager unexpected and make role matching fucntion lost.

resolve: #318 

Signed-off-by: Zxilly <zhouxinyu1001@gmail.com>