### PR TITLE
fix: *matcher result should be boolean or number* for KeyGet2

### DIFF
--- a/examples/basic_keyget2_model.conf
+++ b/examples/basic_keyget2_model.conf
@@ -1,0 +1,11 @@
+[request_definition]
+r = sub, obj
+
+[policy_definition]
+p = sub, obj
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = keyGet2(r.obj, p.obj, 'id')

--- a/examples/basic_keyget2_policy.csv
+++ b/examples/basic_keyget2_policy.csv
@@ -1,2 +1,1 @@
 p, alice, /data/:id
-p, alice, /data/:id

--- a/examples/basic_keyget2_policy.csv
+++ b/examples/basic_keyget2_policy.csv
@@ -1,0 +1,2 @@
+p, alice, /data/:id
+p, alice, /data/:id

--- a/src/coreEnforcer.ts
+++ b/src/coreEnforcer.ts
@@ -457,6 +457,13 @@ export class CoreEnforcer {
               eftRes = result;
             }
             break;
+          case 'string':
+            if (result === '') {
+              eftRes = Effect.Indeterminate;
+            } else {
+              eftRes = Effect.Allow;
+            }
+            break;
           default:
             throw new Error('matcher result should be boolean or number');
         }

--- a/src/coreEnforcer.ts
+++ b/src/coreEnforcer.ts
@@ -465,7 +465,7 @@ export class CoreEnforcer {
             }
             break;
           default:
-            throw new Error('matcher result should be boolean or number');
+            throw new Error('matcher result should only be of type boolean, number, or string');
         }
 
         const eft = parameters['p_eft'];

--- a/test/enforcer.test.ts
+++ b/test/enforcer.test.ts
@@ -659,3 +659,10 @@ test('TestBatchEnforce', async () => {
   ];
   expect(await e.batchEnforce(requests)).toEqual([true, true]);
 });
+
+test('TestKeyGet2', async () => {
+  const e = await newEnforcer('examples/basic_keyget2_model.conf', 'examples/basic_keyget2_policy.csv');
+  expect(await e.enforce('alice', 'data')).toBe(false);
+  expect(await e.enforce('alice', '/data')).toBe(false);
+  expect(await e.enforce('alice', '/data/1')).toBe(true);
+});


### PR DESCRIPTION
Fix: https://github.com/casbin/node-casbin/issues/332

- added a case for result type string.
- please suggest changes if required.