### PR TITLE
feat(rbac): implement `getUsersForRoleInDomain` & `getRolesForUserInDomain`

### DIFF
--- a/src/enforcer.ts
+++ b/src/enforcer.ts
@@ -372,6 +372,30 @@ export class Enforcer extends ManagementEnforcer {
   }
 
   /**
+   * getRolesForUserInDomain gets the roles that a user has inside a domain
+   * An alias for getRolesForUser with the domain params.
+   *
+   * @param name the user.
+   * @param domain the domain.
+   * @return the roles that the user has.
+   */
+  public async getRolesForUserInDomain(name: string, domain: string): Promise<string[]> {
+    return this.getRolesForUser(name, domain);
+  }
+
+  /**
+   * getUsersForRoleInFomain gets the users that has a role inside a domain
+   * An alias for getUsesForRole with the domain params.
+   *
+   * @param name the role.
+   * @param domain the domain.
+   * @return the users that has the role.
+   */
+  public async getUsersForRoleInDomain(name: string, domain: string): Promise<string[]> {
+    return this.getUsersForRole(name, domain);
+  }
+
+  /**
    * getImplicitUsersForPermission gets implicit users for a permission.
    * For example:
    * p, admin, data1, read

--- a/test/rbacwDomainAPI.test.ts
+++ b/test/rbacwDomainAPI.test.ts
@@ -1,0 +1,31 @@
+// Copyright 2019 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { newEnforcer } from '../src';
+
+test('test getRolesForUserInDomain', async () => {
+  const e = await newEnforcer('examples/rbac_with_domains_model.conf', 'examples/rbac_with_domains_policy.csv');
+  expect(await e.getRolesForUserInDomain('alice', 'domain1')).toEqual(['admin']);
+  expect(await e.getRolesForUserInDomain('alice', 'domain2')).toEqual([]);
+  expect(await e.getRolesForUserInDomain('bob', 'domain1')).toEqual([]);
+  expect(await e.getRolesForUserInDomain('bob', 'domain2')).toEqual(['admin']);
+});
+
+test('test getUsersForRoleInDomain', async () => {
+  const e = await newEnforcer('examples/rbac_with_domains_model.conf', 'examples/rbac_with_domains_policy.csv');
+  expect(await e.getUsersForRoleInDomain('admin', 'domain1')).toEqual(['alice']);
+  expect(await e.getUsersForRoleInDomain('admin', 'domain2')).toEqual(['bob']);
+  expect(await e.getUsersForRoleInDomain('superadmin', 'domain1')).toEqual([]);
+  expect(await e.getUsersForRoleInDomain('superadmin', 'domain2')).toEqual([]);
+});


### PR DESCRIPTION
Documentation indicates that there is existance of `getUsersForRoleInDomain` and
`getRolesForUserInDomain` api, but it does not yet exists. This commit implements these functions,
by aliasing them to existing rbac function that had already cater for domain apis, to increase and
improve dev experience.

Fix: https://github.com/casbin/node-casbin/issues/304