### PR TITLE
feat: add support for g() in SyncedEnforcer

### DIFF
--- a/src/coreEnforcer.ts
+++ b/src/coreEnforcer.ts
@@ -21,6 +21,7 @@ import { DefaultRoleManager, RoleManager } from './rbac';
 import {
   escapeAssertion,
   generateGFunction,
+  generateSyncedGFunction,
   getEvalValue,
   hasEval,
   replaceEval,
@@ -384,7 +385,7 @@ export class CoreEnforcer {
 
     astMap?.forEach((value, key) => {
       const rm = value.rm;
-      functions[key] = generateGFunction(rm);
+      functions[key] = asyncCompile ? generateGFunction(rm) : generateSyncedGFunction(rm);
     });
 
     const expString = this.model.model.get('m')?.get('m')?.value;

--- a/src/rbac/defaultRoleManager.ts
+++ b/src/rbac/defaultRoleManager.ts
@@ -257,7 +257,7 @@ export class DefaultRoleManager implements RoleManager {
    * hasLink determines whether role: name1 inherits role: name2.
    * domain is a prefix to the roles.
    */
-  public async hasLink(name1: string, name2: string, ...domain: string[]): Promise<boolean> {
+  public syncedHasLink(name1: string, name2: string, ...domain: string[]): boolean {
     if (domain.length === 0) {
       domain = [DEFAULT_DOMAIN];
     } else if (domain.length > 1) {
@@ -281,6 +281,10 @@ export class DefaultRoleManager implements RoleManager {
 
     const role1 = allRoles.createRole(name1, this.matchingFunc);
     return role1.hasRole(name2, this.maxHierarchyLevel);
+  }
+
+  public async hasLink(name1: string, name2: string, ...domain: string[]): Promise<boolean> {
+    return new Promise((resolve) => resolve(this.syncedHasLink(name1, name2, ...domain)));
   }
 
   /**

--- a/src/rbac/roleManager.ts
+++ b/src/rbac/roleManager.ts
@@ -25,6 +25,9 @@ export interface RoleManager {
   // HasLink determines whether a link exists between two roles. role: name1 inherits role: name2.
   // domain is a prefix to the roles (can be used for other purposes).
   hasLink(name1: string, name2: string, ...domain: string[]): Promise<boolean>;
+  // syncedHasLink is same as hasLink, but not wrapped in promise. Should not be called
+  // if the matchers contain an asynchronous method. Can increase performance.
+  syncedHasLink?(name1: string, name2: string, ...domain: string[]): boolean;
   // GetRoles gets the roles that a user inherits.
   // domain is a prefix to the roles (can be used for other purposes).
   getRoles(name: string, ...domain: string[]): Promise<string[]>;

--- a/src/util/builtinOperators.ts
+++ b/src/util/builtinOperators.ts
@@ -311,7 +311,7 @@ function globMatch(string: string, pattern: string): boolean {
 // generateGFunction is the factory method of the g(_, _) function.
 function generateGFunction(rm: rbac.RoleManager): any {
   const memorized = new Map<string, boolean>();
-  return async function func(...args: any[]): Promise<boolean> {
+  return async function (...args: any[]): Promise<boolean> {
     const key = args.toString();
     let value = memorized.get(key);
     if (value) {
@@ -336,6 +336,36 @@ function generateGFunction(rm: rbac.RoleManager): any {
   };
 }
 
+// generateSyncedGFunction is the synchronous factory method of the g(_, _) function.
+function generateSyncedGFunction(rm: rbac.RoleManager): any {
+  const memorized = new Map<string, boolean>();
+  return function (...args: any[]): boolean {
+    const key = args.toString();
+    let value = memorized.get(key);
+    if (value) {
+      return value;
+    }
+
+    const [arg0, arg1] = args;
+    const name1: string = (arg0 || '').toString();
+    const name2: string = (arg1 || '').toString();
+
+    if (!rm) {
+      value = name1 === name2;
+    } else if (!rm?.syncedHasLink) {
+      throw new Error('RoleManager requires syncedHasLink for synchronous execution');
+    } else if (args.length === 2) {
+      value = rm.syncedHasLink(name1, name2);
+    } else {
+      const domain: string = args[2].toString();
+      value = rm.syncedHasLink(name1, name2, domain);
+    }
+
+    memorized.set(key, value);
+    return value;
+  };
+}
+
 export {
   keyMatchFunc,
   keyGetFunc,
@@ -344,6 +374,7 @@ export {
   keyMatch3Func,
   regexMatchFunc,
   ipMatchFunc,
+  generateSyncedGFunction,
   generateGFunction,
   keyMatch4Func,
   keyMatch5Func,

--- a/test/syncedEnforcer.test.ts
+++ b/test/syncedEnforcer.test.ts
@@ -1,0 +1,82 @@
+import { newModel, newSyncedEnforcer } from '../src';
+
+test('TestGFunctionInSyncedEnforcerWithRoles', async () => {
+  const m = newModel();
+  m.addDef('r', 'r', 'sub, obj, act');
+  m.addDef('p', 'p', 'sub, obj, act');
+  m.addDef('g', 'g', '_, _');
+  m.addDef('e', 'e', 'some(where (p.eft == allow))');
+  m.addDef('m', 'm', 'g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act');
+
+  const e = await newSyncedEnforcer(m);
+
+  await e.addPermissionForUser('alice', 'data1', 'read');
+  await e.addPermissionForUser('bob', 'data2', 'write');
+  await e.addPermissionForUser('data2_admin', 'data2', 'read');
+  await e.addPermissionForUser('data2_admin', 'data2', 'write');
+
+  // Synced enforcer should not fail to recognize subject
+  expect(e.enforceSync('alice', 'data1', 'read')).toBe(true);
+  expect(e.enforceSync('alice', 'data2', 'read')).toBe(false);
+  expect(e.enforceSync('alice', 'data2', 'write')).toBe(false);
+  expect(e.enforceSync('bob', 'data1', 'read')).toBe(false);
+  expect(e.enforceSync('bob', 'data2', 'write')).toBe(true);
+  expect(e.enforceSync('data2_admin', 'data2', 'read')).toBe(true);
+  expect(e.enforceSync('data2_admin', 'data2', 'write')).toBe(true);
+  expect(e.enforceSync('data2_admin', 'data1', 'read')).toBe(false);
+
+  await e.addRoleForUser('alice', 'data2_admin');
+
+  // Synced enforcer should not fail to recognize subject
+  expect(e.enforceSync('alice', 'data1', 'read')).toBe(true);
+  expect(e.enforceSync('alice', 'data2', 'read')).toBe(true);
+  expect(e.enforceSync('alice', 'data2', 'write')).toBe(true);
+  expect(e.enforceSync('bob', 'data1', 'read')).toBe(false);
+  expect(e.enforceSync('bob', 'data2', 'write')).toBe(true);
+  expect(e.enforceSync('data2_admin', 'data2', 'read')).toBe(true);
+  expect(e.enforceSync('data2_admin', 'data2', 'write')).toBe(true);
+  expect(e.enforceSync('data2_admin', 'data1', 'read')).toBe(false);
+});
+
+test('TestGFunctionInSyncedEnforcerWithDomains', async () => {
+  const m = newModel();
+  m.addDef('r', 'r', 'sub, dom, obj, act');
+  m.addDef('p', 'p', 'sub, dom, obj, act');
+  m.addDef('g', 'g', '_, _, _');
+  m.addDef('e', 'e', 'some(where (p.eft == allow))');
+  m.addDef('m', 'm', 'g(r.sub, p.sub, r.dom) && r.dom == p.dom && r.obj == p.obj && r.act == p.act');
+
+  const e = await newSyncedEnforcer(m);
+
+  await e.addPermissionForUser('admin', 'domain1', 'data1', 'read');
+  await e.addPermissionForUser('admin', 'domain1', 'data1', 'write');
+  await e.addPermissionForUser('admin', 'domain2', 'data2', 'read');
+  await e.addPermissionForUser('admin', 'domain2', 'data2', 'write');
+
+  // Alice and Bob should not have rights
+  expect(e.enforceSync('alice', 'domain1', 'data1', 'read')).toBe(false);
+  expect(e.enforceSync('alice', 'domain1', 'data1', 'write')).toBe(false);
+  expect(e.enforceSync('bob', 'domain2', 'data2', 'read')).toBe(false);
+  expect(e.enforceSync('bob', 'domain2', 'data2', 'write')).toBe(false);
+
+  await e.addRoleForUser('alice', 'admin', 'domain1');
+  await e.addRoleForUser('bob', 'admin', 'domain2');
+
+  // Alice and Bob should have rights
+  expect(e.enforceSync('alice', 'domain1', 'data1', 'read')).toBe(true);
+  expect(e.enforceSync('alice', 'domain1', 'data1', 'write')).toBe(true);
+  expect(e.enforceSync('bob', 'domain2', 'data2', 'read')).toBe(true);
+  expect(e.enforceSync('bob', 'domain2', 'data2', 'write')).toBe(true);
+
+  // Alice and Bob should not have rights
+  expect(e.enforceSync('alice', 'domain2', 'data2', 'read')).toBe(false);
+  expect(e.enforceSync('alice', 'domain2', 'data2', 'write')).toBe(false);
+  expect(e.enforceSync('bob', 'domain1', 'data2', 'read')).toBe(false);
+  expect(e.enforceSync('bob', 'domain1', 'data2', 'write')).toBe(false);
+
+  // Domains should be respected
+  expect(e.enforceSync('alice', 'domain2', 'data1', 'read')).toBe(false);
+  expect(e.enforceSync('alice', 'domain2', 'data1', 'write')).toBe(false);
+  expect(e.enforceSync('bob', 'domain1', 'data2', 'read')).toBe(false);
+  expect(e.enforceSync('bob', 'domain1', 'data2', 'write')).toBe(false);
+});


### PR DESCRIPTION
Based on @Zxilly 's work in: https://github.com/casbin/node-casbin/pull/303

Fixed the issue of `generateGFuncion` being async, therefore not working in syncedEnforcer.

I am not sure if the implementation is clear enough, but I created some tests which should cover the issue pretty well.