### PR TITLE
feat(defaultrolemanager.ts): add hierarchical domain support for rbac

### DIFF
--- a/examples/rbac_with_hierarchical_domains_model.conf
+++ b/examples/rbac_with_hierarchical_domains_model.conf
@@ -1,0 +1,15 @@
+[request_definition]
+r = sub, dom, obj, act
+
+[policy_definition]
+p = sub, dom, obj, act
+
+[role_definition]
+g = _, _, _
+g2 = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub, r.dom) && g2(r.dom, p.dom) && r.obj == p.obj && regexMatch(r.act, p.act)

--- a/examples/rbac_with_hierarchical_domains_policy.csv
+++ b/examples/rbac_with_hierarchical_domains_policy.csv
@@ -1,0 +1,10 @@
+p, admin, domain1, data1, (read|write)
+p, admin, domain2, data2, (read|write)
+p, admin, domain3, data3, (write)
+p, admin, sibling2, sdata2, (read|write)
+
+g, alice, admin, domain1
+g, bob, admin, domain2
+g2, domain1, domain2
+g2, domain1, sibling2
+g2, domain2, domain3

--- a/test/rbacHierarchicalDomain.test.ts
+++ b/test/rbacHierarchicalDomain.test.ts
@@ -1,0 +1,79 @@
+import { DefaultRoleManager, newSyncedEnforcer, RoleManager, SyncedEnforcer } from '../src';
+
+describe('Test Hierarchical Domain RBAC', () => {
+  let e: SyncedEnforcer;
+  beforeAll(async () => {
+    e = await newSyncedEnforcer('examples/rbac_with_hierarchical_domains_model.conf', 'examples/rbac_with_hierarchical_domains_policy.csv');
+    await (e.getRoleManager() as DefaultRoleManager).addDomainHierarchy(e.getNamedRoleManager('g2') as RoleManager);
+  });
+
+  test('Authorization to lower domain should pass', async () => {
+    expect(e.enforceSync('alice', 'domain1', 'data1', 'read')).toBe(true);
+    expect(e.enforceSync('alice', 'domain1', 'data2', 'read')).toBe(true);
+    expect(e.enforceSync('alice', 'domain2', 'data2', 'read')).toBe(true);
+    expect(e.enforceSync('alice', 'domain1', 'sdata2', 'read')).toBe(true);
+    expect(e.enforceSync('alice', 'sibling2', 'sdata2', 'read')).toBe(true);
+    expect(e.enforceSync('alice', 'domain3', 'data3', 'write')).toBe(true);
+    expect(e.enforceSync('alice', 'domain1', 'data3', 'write')).toBe(true);
+    expect(e.enforceSync('alice', 'domain2', 'data3', 'write')).toBe(true);
+    expect(e.enforceSync('bob', 'domain2', 'data2', 'read')).toBe(true);
+    expect(e.enforceSync('bob', 'domain2', 'data3', 'write')).toBe(true);
+    expect(e.enforceSync('bob', 'domain3', 'data3', 'write')).toBe(true);
+  });
+
+  test('Authorization to lower domain should faill if no role', async () => {
+    expect(e.enforceSync('bob', 'domain1', 'data3', 'write')).toBe(false);
+    expect(e.enforceSync('bob', 'domain1', 'data2', 'read')).toBe(false);
+  });
+
+  test('Authorization to higher domain without permissions should faill', async () => {
+    expect(e.enforceSync('bob', 'domain1', 'data1', 'read')).toBe(false);
+    expect(e.enforceSync('bob', 'domain2', 'data1', 'read')).toBe(false);
+    expect(e.enforceSync('bob', 'domain3', 'data1', 'write')).toBe(false);
+  });
+
+  test('Authorization to higher domain with permissions should faill', async () => {
+    // alice data1
+    expect(e.enforceSync('alice', 'domain2', 'data1', 'read')).toBe(false);
+    expect(e.enforceSync('alice', 'domain3', 'data1', 'read')).toBe(false);
+    expect(e.enforceSync('alice', 'sibling2', 'data1', 'read')).toBe(false);
+    // alice data2
+    expect(e.enforceSync('alice', 'domain3', 'data2', 'read')).toBe(false);
+    expect(e.enforceSync('alice', 'sibling2', 'data2', 'read')).toBe(false);
+    // alice data3
+    expect(e.enforceSync('alice', 'sibling2', 'data3', 'write')).toBe(false);
+    // alice sdata2
+    expect(e.enforceSync('alice', 'domain2', 'sdata2', 'read')).toBe(false);
+    // bob data2
+    expect(e.enforceSync('bob', 'domain3', 'data2', 'read')).toBe(false);
+  });
+
+  test('Authorization to sibling without permissions should faill', async () => {
+    expect(e.enforceSync('bob', 'domain1', 'sdata2', 'read')).toBe(false);
+    expect(e.enforceSync('bob', 'domain2', 'sdata2', 'read')).toBe(false);
+    expect(e.enforceSync('bob', 'sibling2', 'sdata2', 'read')).toBe(false);
+    expect(e.enforceSync('bob', 'domain3', 'sdata2', 'read')).toBe(false);
+  });
+
+  test('User should not have a permission if there is none in the lower domain', async () => {
+    expect(e.enforceSync('alice', 'domain3', 'data3', 'read')).toBe(false);
+    expect(e.enforceSync('bob', 'domain3', 'data3', 'read')).toBe(false);
+  });
+
+  test('test getRolesForUserInDomain', async () => {
+    expect(await e.getRolesForUserInDomain('alice', 'domain1')).toEqual(['admin']);
+    expect(await e.getRolesForUserInDomain('alice', 'domain2')).toEqual(['admin']);
+    expect(await e.getRolesForUserInDomain('alice', 'domain3')).toEqual(['admin']);
+    expect(await e.getRolesForUserInDomain('alice', 'sibling2')).toEqual(['admin']);
+    expect(await e.getRolesForUserInDomain('bob', 'domain1')).toEqual([]);
+    expect(await e.getRolesForUserInDomain('bob', 'domain2')).toEqual(['admin']);
+    expect(await e.getRolesForUserInDomain('bob', 'domain3')).toEqual(['admin']);
+  });
+
+  test('test getUsersForRoleInDomain', async () => {
+    expect(await e.getUsersForRoleInDomain('admin', 'domain1')).toEqual(['alice']);
+    expect(await e.getUsersForRoleInDomain('admin', 'domain2')).toEqual(['bob', 'alice']);
+    expect(await e.getUsersForRoleInDomain('admin', 'sibling2')).toEqual(['alice']);
+    expect(await e.getUsersForRoleInDomain('admin', 'domain3')).toEqual(['alice', 'bob']);
+  });
+});


### PR DESCRIPTION
Work in progress. Initial idea from https://github.com/casbin/casbin/pull/1040

- [x] add basic functionality to the `roleManager`
- [x] Fix related helper functions
- [ ] Add documentation?
- [x] Rebase from master when https://github.com/casbin/node-casbin/pull/378 merged

g2 defitions are in "reverse" order for reason. Other way around it would not work.

Discussion welcome.