### PR TITLE
feat: add management api for watcherEx callbacks

### DIFF
--- a/src/internalEnforcer.ts
+++ b/src/internalEnforcer.ts
@@ -24,7 +24,7 @@ export class InternalEnforcer extends CoreEnforcer {
   /**
    * addPolicyInternal adds a rule to the current policy.
    */
-  public async addPolicyInternal(sec: string, ptype: string, rule: string[]): Promise<boolean> {
+  protected async addPolicyInternal(sec: string, ptype: string, rule: string[], useWatcher: boolean): Promise<boolean> {
     if (this.model.hasPolicy(sec, ptype, rule)) {
       return false;
     }
@@ -39,10 +39,15 @@ export class InternalEnforcer extends CoreEnforcer {
       }
     }
 
-    if (this.autoNotifyWatcher) {
-      // error intentionally ignored
-      if (this.watcherEx) await this.watcherEx.updateForAddPolicy(sec, ptype, ...rule);
-      else if (this.watcher) await this.watcher.update();
+    if (useWatcher) {
+      if (this.autoNotifyWatcher) {
+        // error intentionally ignored
+        if (this.watcherEx) {
+          this.watcherEx.updateForAddPolicy(sec, ptype, ...rule);
+        } else if (this.watcher) {
+          this.watcher.update();
+        }
+      }
     }
 
     const ok = this.model.addPolicy(sec, ptype, rule);
@@ -55,7 +60,7 @@ export class InternalEnforcer extends CoreEnforcer {
 
   // addPolicies adds rules to the current policy.
   // removePolicies removes rules from the current policy.
-  public async addPoliciesInternal(sec: string, ptype: string, rules: string[][]): Promise<boolean> {
+  protected async addPoliciesInternal(sec: string, ptype: string, rules: string[][], useWatcher: boolean): Promise<boolean> {
     for (const rule of rules) {
       if (this.model.hasPolicy(sec, ptype, rule)) {
         return false;
@@ -76,10 +81,15 @@ export class InternalEnforcer extends CoreEnforcer {
       }
     }
 
-    if (this.autoNotifyWatcher) {
-      // error intentionally ignored
-      if (this.watcherEx) await this.watcherEx.updateForAddPolicies(sec, ptype, ...rules);
-      else if (this.watcher) this.watcher.update();
+    if (useWatcher) {
+      if (this.autoNotifyWatcher) {
+        // error intentionally ignored
+        if (this.watcherEx) {
+          this.watcherEx.updateForAddPolicies(sec, ptype, ...rules);
+        } else if (this.watcher) {
+          this.watcher.update();
+        }
+      }
     }
 
     const [ok, effects] = await this.model.addPolicies(sec, ptype, rules);
@@ -92,7 +102,13 @@ export class InternalEnforcer extends CoreEnforcer {
   /**
    * updatePolicyInternal updates a rule from the current policy.
    */
-  public async updatePolicyInternal(sec: string, ptype: string, oldRule: string[], newRule: string[]): Promise<boolean> {
+  protected async updatePolicyInternal(
+    sec: string,
+    ptype: string,
+    oldRule: string[],
+    newRule: string[],
+    useWatcher: boolean
+  ): Promise<boolean> {
     if (!this.model.hasPolicy(sec, ptype, oldRule)) {
       return false;
     }
@@ -111,10 +127,12 @@ export class InternalEnforcer extends CoreEnforcer {
       }
     }
 
-    if (this.watcher && this.autoNotifyWatcher) {
-      // In fact I think it should wait for the respond, but they implement add_policy() like this
-      // error intentionally ignored
-      this.watcher.update();
+    if (useWatcher) {
+      if (this.watcher && this.autoNotifyWatcher) {
+        // In fact I think it should wait for the respond, but they implement add_policy() like this
+        // error intentionally ignored
+        this.watcher.update();
+      }
     }
 
     const ok = this.model.updatePolicy(sec, ptype, oldRule, newRule);
@@ -129,7 +147,7 @@ export class InternalEnforcer extends CoreEnforcer {
   /**
    * removePolicyInternal removes a rule from the current policy.
    */
-  public async removePolicyInternal(sec: string, ptype: string, rule: string[]): Promise<boolean> {
+  protected async removePolicyInternal(sec: string, ptype: string, rule: string[], useWatcher: boolean): Promise<boolean> {
     if (!this.model.hasPolicy(sec, ptype, rule)) {
       return false;
     }
@@ -144,10 +162,15 @@ export class InternalEnforcer extends CoreEnforcer {
       }
     }
 
-    if (this.watcher && this.autoNotifyWatcher) {
-      // error intentionally ignored
-      if (this.watcherEx) await this.watcherEx.updateForRemovePolicy(sec, ptype, ...rule);
-      else if (this.watcher) await this.watcher.update();
+    if (useWatcher) {
+      if (this.watcher && this.autoNotifyWatcher) {
+        // error intentionally ignored
+        if (this.watcherEx) {
+          this.watcherEx.updateForRemovePolicy(sec, ptype, ...rule);
+        } else if (this.watcher) {
+          this.watcher.update();
+        }
+      }
     }
 
     const ok = await this.model.removePolicy(sec, ptype, rule);
@@ -158,7 +181,7 @@ export class InternalEnforcer extends CoreEnforcer {
   }
 
   // removePolicies removes rules from the current policy.
-  public async removePoliciesInternal(sec: string, ptype: string, rules: string[][]): Promise<boolean> {
+  protected async removePoliciesInternal(sec: string, ptype: string, rules: string[][], useWatcher: boolean): Promise<boolean> {
     for (const rule of rules) {
       if (!this.model.hasPolicy(sec, ptype, rule)) {
         return false;
@@ -179,10 +202,15 @@ export class InternalEnforcer extends CoreEnforcer {
       }
     }
 
-    if (this.watcher && this.autoNotifyWatcher) {
-      // error intentionally ignored
-      if (this.watcherEx) await this.watcherEx.updateForRemovePolicies(sec, ptype, ...rules);
-      else if (this.watcher) await this.watcher.update();
+    if (useWatcher) {
+      if (this.watcher && this.autoNotifyWatcher) {
+        // error intentionally ignored
+        if (this.watcherEx) {
+          this.watcherEx.updateForRemovePolicies(sec, ptype, ...rules);
+        } else if (this.watcher) {
+          this.watcher.update();
+        }
+      }
     }
 
     const [ok, effects] = this.model.removePolicies(sec, ptype, rules);
@@ -195,7 +223,13 @@ export class InternalEnforcer extends CoreEnforcer {
   /**
    * removeFilteredPolicyInternal removes rules based on field filters from the current policy.
    */
-  public async removeFilteredPolicyInternal(sec: string, ptype: string, fieldIndex: number, fieldValues: string[]): Promise<boolean> {
+  protected async removeFilteredPolicyInternal(
+    sec: string,
+    ptype: string,
+    fieldIndex: number,
+    fieldValues: string[],
+    useWatcher: boolean
+  ): Promise<boolean> {
     if (this.adapter && this.autoSave) {
       try {
         await this.adapter.removeFilteredPolicy(sec, ptype, fieldIndex, ...fieldValues);
@@ -206,10 +240,15 @@ export class InternalEnforcer extends CoreEnforcer {
       }
     }
 
-    if (this.watcher && this.autoNotifyWatcher) {
-      // error intentionally ignored
-      if (this.watcherEx) await this.watcherEx.updateForRemoveFilteredPolicy(sec, ptype, fieldIndex, ...fieldValues);
-      else if (this.watcher) await this.watcher.update();
+    if (useWatcher) {
+      if (this.watcher && this.autoNotifyWatcher) {
+        // error intentionally ignored
+        if (this.watcherEx) {
+          this.watcherEx.updateForRemoveFilteredPolicy(sec, ptype, fieldIndex, ...fieldValues);
+        } else if (this.watcher) {
+          this.watcher.update();
+        }
+      }
     }
 
     const [ok, effects] = this.model.removeFilteredPolicy(sec, ptype, fieldIndex, ...fieldValues);

--- a/src/managementEnforcer.ts
+++ b/src/managementEnforcer.ts
@@ -260,7 +260,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async addNamedPolicy(ptype: string, ...params: string[]): Promise<boolean> {
-    return this.addPolicyInternal('p', ptype, params);
+    return this.addPolicyInternal('p', ptype, params, true);
   }
 
   /**
@@ -273,7 +273,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async addNamedPolicies(ptype: string, rules: string[][]): Promise<boolean> {
-    return this.addPoliciesInternal('p', ptype, rules);
+    return this.addPoliciesInternal('p', ptype, rules, true);
   }
 
   /**
@@ -300,7 +300,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async updateNamedPolicy(ptype: string, oldRule: string[], newRule: string[]): Promise<boolean> {
-    return this.updatePolicyInternal('p', ptype, oldRule, newRule);
+    return this.updatePolicyInternal('p', ptype, oldRule, newRule, true);
   }
 
   /**
@@ -343,7 +343,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async removeNamedPolicy(ptype: string, ...params: string[]): Promise<boolean> {
-    return this.removePolicyInternal('p', ptype, params);
+    return this.removePolicyInternal('p', ptype, params, true);
   }
 
   /**
@@ -354,7 +354,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async removeNamedPolicies(ptype: string, rules: string[][]): Promise<boolean> {
-    return this.removePoliciesInternal('p', ptype, rules);
+    return this.removePoliciesInternal('p', ptype, rules, true);
   }
 
   /**
@@ -367,7 +367,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async removeFilteredNamedPolicy(ptype: string, fieldIndex: number, ...fieldValues: string[]): Promise<boolean> {
-    return this.removeFilteredPolicyInternal('p', ptype, fieldIndex, fieldValues);
+    return this.removeFilteredPolicyInternal('p', ptype, fieldIndex, fieldValues, true);
   }
 
   /**
@@ -425,7 +425,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async addNamedGroupingPolicy(ptype: string, ...params: string[]): Promise<boolean> {
-    return this.addPolicyInternal('g', ptype, params);
+    return this.addPolicyInternal('g', ptype, params, true);
   }
 
   /**
@@ -438,7 +438,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async addNamedGroupingPolicies(ptype: string, rules: string[][]): Promise<boolean> {
-    return this.addPoliciesInternal('g', ptype, rules);
+    return this.addPoliciesInternal('g', ptype, rules, true);
   }
 
   /**
@@ -481,7 +481,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async removeNamedGroupingPolicy(ptype: string, ...params: string[]): Promise<boolean> {
-    return this.removePolicyInternal('g', ptype, params);
+    return this.removePolicyInternal('g', ptype, params, true);
   }
 
   /**
@@ -492,7 +492,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async removeNamedGroupingPolicies(ptype: string, rules: string[][]): Promise<boolean> {
-    return this.removePoliciesInternal('g', ptype, rules);
+    return this.removePoliciesInternal('g', ptype, rules, true);
   }
 
   /**
@@ -505,7 +505,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    * @return succeeds or not.
    */
   public async removeFilteredNamedGroupingPolicy(ptype: string, fieldIndex: number, ...fieldValues: string[]): Promise<boolean> {
-    return this.removeFilteredPolicyInternal('g', ptype, fieldIndex, fieldValues);
+    return this.removeFilteredPolicyInternal('g', ptype, fieldIndex, fieldValues, true);
   }
 
   /**
@@ -515,5 +515,29 @@ export class ManagementEnforcer extends InternalEnforcer {
    */
   public async addFunction(name: string, func: MatchingFunction): Promise<void> {
     this.fm.addFunction(name, func);
+  }
+
+  public async selfAddPolicy(sec: string, ptype: string, rule: string[]): Promise<boolean> {
+    return this.addPolicyInternal(sec, ptype, rule, false);
+  }
+
+  public async selfRemovePolicy(sec: string, ptype: string, rule: string[]): Promise<boolean> {
+    return this.removePolicyInternal(sec, ptype, rule, false);
+  }
+
+  public async selfRemoveFilteredPolicy(sec: string, ptype: string, fieldIndex: number, fieldValues: string[]): Promise<boolean> {
+    return this.removeFilteredPolicyInternal(sec, ptype, fieldIndex, fieldValues, false);
+  }
+
+  public async selfUpdatePolicy(sec: string, ptype: string, oldRule: string[], newRule: string[]): Promise<boolean> {
+    return this.updatePolicyInternal(sec, ptype, oldRule, newRule, false);
+  }
+
+  public async selfAddPolicies(sec: string, ptype: string, rule: string[][]): Promise<boolean> {
+    return this.addPoliciesInternal(sec, ptype, rule, false);
+  }
+
+  public async selfRemovePolicies(sec: string, ptype: string, rule: string[][]): Promise<boolean> {
+    return this.removePoliciesInternal(sec, ptype, rule, false);
   }
 }

--- a/src/syncedEnforcer.ts
+++ b/src/syncedEnforcer.ts
@@ -366,7 +366,7 @@ export class SyncedEnforcer extends Enforcer {
    */
   public async removeNamedPolicy(ptype: string, ...params: string[]): Promise<boolean> {
     await this.lock.acquireAsync();
-    return this.removePolicyInternal('p', ptype, params).finally(() => this.lock.release());
+    return this.removePolicyInternal('p', ptype, params, true).finally(() => this.lock.release());
   }
 
   /**


### PR DESCRIPTION
- ref: https://github.com/casbin/casbin/issues/1092
- Moved all watcher calls from Internal methods to management enforcer