### PR TITLE
fix: update express-eval dependency to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casbin",
-  "version": "5.19.2",
+  "version": "5.19.3",
   "description": "An authorization library that supports access control models like ACL, RBAC, ABAC in Node.JS",
   "main": "lib/cjs/index.js",
   "typings": "lib/cjs/index.d.ts",
@@ -28,8 +28,8 @@
     "@semantic-release/release-notes-generator": "^9.0.3",
     "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.168",
-    "@types/picomatch": "^2.2.2",
     "@types/node": "^10.5.3",
+    "@types/picomatch": "^2.2.2",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "coveralls": "^3.0.2",
@@ -52,7 +52,7 @@
   "dependencies": {
     "await-lock": "^2.0.1",
     "csv-parse": "^4.15.3",
-    "expression-eval": "^4.0.0",
+    "expression-eval": "^5.0.0",
     "picomatch": "^2.2.3"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casbin",
-  "version": "5.19.3",
+  "version": "5.19.2",
   "description": "An authorization library that supports access control models like ACL, RBAC, ABAC in Node.JS",
   "main": "lib/cjs/index.js",
   "typings": "lib/cjs/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,10 +2885,10 @@ expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
-expression-eval@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/expression-eval/-/expression-eval-4.0.0.tgz#d6a07c93e8b33e635710419d4a595d9208b9cc5e"
-  integrity sha512-YHSnLTyIb9IKaho2IdQbvlei/pElxnGm48UgaXJ1Fe5au95Ck0R9ftm6rHJQuKw3FguZZ4eXVllJFFFc7LX0WQ==
+expression-eval@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/expression-eval/-/expression-eval-5.0.0.tgz#0add5fa9e12c9bbaa8e81f16fc9e560599523afd"
+  integrity sha512-2H7OBTa/UKBgTVRRb3/lXd+D89cLjClNtldnzOpZYWZK1zBLIlrz8BLWp5f81AAYOc37GbhkCRXtl5Z/q4D91g==
   dependencies:
     jsep "^0.3.0"
 


### PR DESCRIPTION
I'm not sure if this [issue](https://github.com/donmccurdy/expression-eval/issues/52) affects node-casbin but node-casbin is causing CI dependency check issues for me because of it. I hope you won't mind accepting my PR.