### PR TITLE
fix: avoid the impact of line breaks CRLF in frontend.test.ts

### DIFF
--- a/test/frontend.test.ts
+++ b/test/frontend.test.ts
@@ -27,7 +27,7 @@ test('TestCasbinJsGetPermissionForUser', async () => {
   let expectedModelStr = readFileSync('examples/rbac_model.conf').toString();
 
   // avoid the impact of line breaks changing to CRLF, when automatic conversion is enabled
-  expectedModelStr = expectedModelStr.replace(/\r/g, '\n')
+  expectedModelStr = expectedModelStr.replace(/\r/g, '\n');
 
   expect(received['m']).toBe(expectedModelStr.replace(/\n\n/g, '\n'));
   const expectedPoliciesStr = readFileSync('examples/rbac_with_hierarchy_policy.csv').toString();

--- a/test/frontend.test.ts
+++ b/test/frontend.test.ts
@@ -24,8 +24,11 @@ test('TestCasbinJsGetPermissionForUser', async () => {
     throw new Error('Unexpected side affect.');
   }
   const received = JSON.parse(await casbinJsGetPermissionForUser(e, 'alice'));
-  const expectedModelStr = readFileSync('examples/rbac_model.conf').toString();
-  // If you enable CR_LF auto transfer on Windows platform, this can lead to some unexpected behavior.
+  let expectedModelStr = readFileSync('examples/rbac_model.conf').toString();
+
+  // avoid the impact of line breaks changing to CRLF, when automatic conversion is enabled
+  expectedModelStr = expectedModelStr.replace(/\r/g, '\n')
+
   expect(received['m']).toBe(expectedModelStr.replace(/\n\n/g, '\n'));
   const expectedPoliciesStr = readFileSync('examples/rbac_with_hierarchy_policy.csv').toString();
 

--- a/test/frontend.test.ts
+++ b/test/frontend.test.ts
@@ -27,7 +27,7 @@ test('TestCasbinJsGetPermissionForUser', async () => {
   let expectedModelStr = readFileSync('examples/rbac_model.conf').toString();
 
   // avoid the impact of line breaks changing to CRLF, when automatic conversion is enabled
-  expectedModelStr = expectedModelStr.replace(/\r/g, '\n');
+  expectedModelStr = expectedModelStr.replace(/\r\n/g, '\n');
 
   expect(received['m']).toBe(expectedModelStr.replace(/\n\n/g, '\n'));
   const expectedPoliciesStr = readFileSync('examples/rbac_with_hierarchy_policy.csv').toString();


### PR DESCRIPTION
Fix: #339

Fix line breaks CRLF in Windows caused the test faild.

![image](https://user-images.githubusercontent.com/41513919/216298891-1a23f89e-84de-479a-a625-0b8f54f9bbd9.png)
