### PR TITLE
fix: using import() to load the fs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,17 +26,3 @@ export * from './rbac';
 export * from './log';
 export * from './frontend';
 export { Util };
-
-if (typeof process !== 'undefined' && process?.versions?.node) {
-  const requireFunc = typeof __non_webpack_require__ === 'function' ? __non_webpack_require__ : require;
-  const fs = requireFunc('fs');
-  const defaultFileSystem = {
-    readFileSync(path: string, encoding?: string) {
-      return fs.readFileSync(path, { encoding });
-    },
-    writeFileSync(path: string, text: string, encoding?: string) {
-      return fs.writeFileSync(path, text, encoding);
-    },
-  };
-  setDefaultFileSystem(defaultFileSystem);
-}

--- a/test/config/config.test.ts
+++ b/test/config/config.test.ts
@@ -1,6 +1,7 @@
 import { Config } from '../../src';
+import { readFileSync } from 'fs';
 
-const config = Config.newConfig('test/config/testini.ini');
+const config = Config.newConfigFromText(readFileSync('test/config/testini.ini').toString());
 
 describe('multi-line test', () => {
   it('should config.get("multi1::name") to equal r.sub==p.sub&&r.obj==p.obj', function () {

--- a/test/model/model.test.ts
+++ b/test/model/model.test.ts
@@ -43,12 +43,6 @@ test('TestNewModel', () => {
   expect(m !== null).toBe(true);
 });
 
-test('TestNewModelFromFile', () => {
-  const m = newModelFromFile(basicExample);
-
-  expect(m !== null).toBe(true);
-});
-
 test('TestNewModelFromString', () => {
   const m = newModelFromString(readFileSync(basicExample).toString());
 

--- a/test/persist/fileSystem.test.ts
+++ b/test/persist/fileSystem.test.ts
@@ -16,7 +16,7 @@ import { FileSystem, getDefaultFileSystem, setDefaultFileSystem } from '../../sr
 
 test('get an set the default system', async () => {
   let fs = getDefaultFileSystem();
-  expect(fs).toBeDefined();
+  expect(fs).toBeUndefined();
   const defaultFileSystem: FileSystem = {
     readFileSync(path: string, encoding?: string): Buffer {
       // noop


### PR DESCRIPTION
The `require` is unavailable in the ESM, so using the `import` instead.

Fix: https://github.com/casbin/node-casbin/issues/434