### PR TITLE
fix(./src/util/util.ts): fixed unwanted replacement of .r in evals

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -17,8 +17,8 @@
 import { mustGetDefaultFileSystem } from '../persist';
 
 function escapeAssertion(s: string): string {
-  s = s.replace(/r\./g, 'r_');
-  s = s.replace(/p\./g, 'p_');
+  s = s.replace(/(?<!\w)r\./g, 'r_');
+  s = s.replace(/(?<!\w)p\./g, 'p_');
   return s;
 }
 


### PR DESCRIPTION
Fix: https://github.com/casbin/node-casbin/issues/438

Fixed unwanted replacement of r. in evals according to issue #438 (e.g. r.obj.owner.id wrongly becoming r_obj.owner_id instead of the correct r_obj.owner.id)
