### PR TITLE
feat: replace picomatch with minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "buffer": "^6.0.3",
     "csv-parse": "^5.3.5",
     "expression-eval": "^5.0.0",
-    "picomatch": "^2.2.3"
+    "minimatch": "^7.4.2"
   },
   "files": [
     "lib",

--- a/src/util/builtinOperators.ts
+++ b/src/util/builtinOperators.ts
@@ -14,7 +14,7 @@
 
 import * as rbac from '../rbac';
 import { ip } from './ip';
-import { isMatch } from 'picomatch';
+import { minimatch } from 'minimatch';
 
 // regexMatch determines whether key1 matches the pattern of key2 in regular expression.
 function regexMatch(key1: string, key2: string): boolean {
@@ -305,7 +305,12 @@ function ipMatchFunc(...args: any[]): boolean {
  * ```
  */
 function globMatch(string: string, pattern: string): boolean {
-  return isMatch(string, pattern);
+  // The minimatch doesn't support the pattern starts with *
+  // See https://github.com/isaacs/minimatch/issues/195
+  if (pattern[0] === '*' && pattern[1] === '/') {
+    pattern = pattern.substring(1);
+  }
+  return minimatch(string, pattern);
 }
 
 // generateGFunction is the factory method of the g(_, _) function.

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -156,6 +156,8 @@ test('test globMatch', () => {
   expect(util.globMatch('/prefix/subprefix/foobar', '*/foo')).toEqual(false);
   expect(util.globMatch('/prefix/subprefix/foobar', '*/foo*')).toEqual(false);
   expect(util.globMatch('/prefix/subprefix/foobar', '*/foo/*')).toEqual(false);
+
+  expect(util.globMatch('a.conf', '*.conf')).toEqual(true);
 });
 
 test('test hasEval', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,6 +1639,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^2.3.1:
   version "2.3.2"
   resolved "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
@@ -5269,6 +5276,13 @@ minimatch@^3.0.4:
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.2.tgz#157e847d79ca671054253b840656720cb733f10f"
+  integrity sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist-options@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Fix https://github.com/casbin/node-casbin/issues/386

Replace: https://github.com/casbin/node-casbin/pull/393

### Motivation

The picomatch cannot be running in the browser, so use the mininmatch instead of the picomatch.
