### PR TITLE
fix: escapeAssertion is compatible with safari

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -17,12 +17,11 @@
 
 import { mustGetDefaultFileSystem } from '../persist';
 
+const escapeAssertionReg = new RegExp(/(^|[^A-Za-z0-9_])([rp])[0-9]*\./g);
+
 function escapeAssertion(s: string): string {
-  s = s.replace(/(?<!\w)r[0-9]*\./g, (match) => {
-    return match.replace('.', '_');
-  });
-  s = s.replace(/(?<!\w)p[0-9]*\./g, (match) => {
-    return match.replace('.', '_');
+  s = s.replace(escapeAssertionReg, (match, p1, p2) => {
+    return p1 + p2 + match.substring(p1.length + p2.length).replace('.', '_');
   });
   return s;
 }


### PR DESCRIPTION
Fix #441 

This regex is generated by @openai chatGPT.

