### PR TITLE
feat: Add support for JSON request parsing in Enforcer

### DIFF
--- a/src/enforcer.ts
+++ b/src/enforcer.ts
@@ -23,6 +23,7 @@ import { FieldIndex } from './constants';
  * Enforcer = ManagementEnforcer + RBAC API.
  */
 export class Enforcer extends ManagementEnforcer {
+  private acceptJsonRequest = false;
   /**
    * initWithFile initializes an enforcer with a model file and a policy file.
    * @param modelPath model file path
@@ -438,6 +439,15 @@ export class Enforcer extends ManagementEnforcer {
   public async getUsersForRoleInDomain(name: string, domain: string): Promise<string[]> {
     return this.getUsersForRole(name, domain);
   }
+
+  /**
+   * Enable or disable accepting JSON requests for ABAC.
+   * @param enable Whether to enable or disable accepting JSON requests.
+   */
+  public enableAcceptJsonRequest(enable: boolean): void {
+    this.acceptJsonRequest = enable;
+  }
+
 
   /**
    * getImplicitUsersForPermission gets implicit users for a permission.

--- a/src/enforcer.ts
+++ b/src/enforcer.ts
@@ -448,7 +448,6 @@ export class Enforcer extends ManagementEnforcer {
     this.acceptJsonRequest = enable;
   }
 
-
   /**
    * getImplicitUsersForPermission gets implicit users for a permission.
    * For example:

--- a/test/enforcer.test.ts
+++ b/test/enforcer.test.ts
@@ -393,6 +393,38 @@ test('TestInitWithAdapter', async () => {
   await testEnforce(e, 'bob', 'data2', 'write', true);
 });
 
+test('TestEnableAcceptJsonRequest', async () => {
+  const m = newModel();
+  const a = new FileAdapter('examples/keymatch_policy.csv');
+  const e = await newEnforcer(m, a);
+
+  // Enable JSON request parsing
+  e.enableAcceptJsonRequest(true);
+
+  // Testing with JSON request
+  const requestJson = '{"sub": "alice", "obj": "/alice_data/resource1", "act": "GET"}';
+  await testEnforce(e, JSON.parse(requestJson), '/alice_data/resource1', 'GET', true);
+  await testEnforce(e, JSON.parse(requestJson), '/alice_data/resource1', 'POST', true);
+  await testEnforce(e, JSON.parse(requestJson), '/alice_data/resource2', 'GET', true);
+  await testEnforce(e, JSON.parse(requestJson), '/alice_data/resource2', 'POST', false);
+  await testEnforce(e, JSON.parse(requestJson), '/bob_data/resource1', 'GET', false);
+  await testEnforce(e, JSON.parse(requestJson), '/bob_data/resource1', 'POST', false);
+  await testEnforce(e, JSON.parse(requestJson), '/bob_data/resource2', 'GET', false);
+  await testEnforce(e, JSON.parse(requestJson), '/bob_data/resource2', 'POST', false);
+
+  // Disabling JSON request parsing
+  e.enableAcceptJsonRequest(false);
+
+  await testEnforce(e, 'alice', '/alice_data/resource1', 'GET', true);
+  await testEnforce(e, 'alice', '/alice_data/resource1', 'POST', true);
+  await testEnforce(e, 'alice', '/alice_data/resource2', 'GET', true);
+  await testEnforce(e, 'alice', '/alice_data/resource2', 'POST', false);
+  await testEnforce(e, 'alice', '/bob_data/resource1', 'GET', false);
+  await testEnforce(e, 'alice', '/bob_data/resource1', 'POST', false);
+  await testEnforce(e, 'alice', '/bob_data/resource2', 'GET', false);
+  await testEnforce(e, 'alice', '/bob_data/resource2', 'POST', false);
+});
+
 test('TestInitWithStringAdapter', async () => {
   const policy = readFileSync('examples/basic_policy.csv').toString();
   const adapter = new StringAdapter(policy);


### PR DESCRIPTION
Addresses #460 

This PR adds support for JSON request parsing in the Enforcer module. The new method `enableAcceptJsonRequest` has been implemented to facilitate parsing request properties as JSON strings which enhances the capability of the Enforcer to handle object ownership, improving the overall functionality and versatility of the system.