### PR TITLE
feat: ensure eft and priority are respected in p2, r2, etc

### DIFF
--- a/src/coreEnforcer.ts
+++ b/src/coreEnforcer.ts
@@ -217,17 +217,18 @@ export class CoreEnforcer {
   }
 
   public sortPolicies(): void {
-    const policy = this.model.model.get('p')?.get('p')?.policy;
-    const tokens = this.model.model.get('p')?.get('p')?.tokens;
-
-    if (policy && tokens) {
-      const priorityIndex = tokens.indexOf('p_priority');
-      if (priorityIndex !== -1) {
-        policy.sort((a, b) => {
-          return parseInt(a[priorityIndex], 10) - parseInt(b[priorityIndex], 10);
-        });
+    this.model.model.get('p')?.forEach((value, key) => {
+      const policy = value.policy;
+      const tokens = value.tokens;
+      if (policy && tokens) {
+        const priorityIndex = tokens.indexOf(`${key}_priority`);
+        if (priorityIndex !== -1) {
+          policy.sort((a, b) => {
+            return parseInt(a[priorityIndex], 10) - parseInt(b[priorityIndex], 10);
+          });
+        }
       }
-    }
+    });
   }
 
   /**
@@ -528,7 +529,7 @@ export class CoreEnforcer {
             throw new Error('matcher result should only be of type boolean, number, or string');
         }
 
-        const eft = parameters['p_eft'];
+        const eft = parameters[`${enforceContext.pType}_eft`];
         if (eft && eftRes === Effect.Allow) {
           if (eft === 'allow') {
             eftRes = Effect.Allow;

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -251,7 +251,7 @@ export class Model {
       const policy = ast.policy;
       const tokens = ast.tokens;
 
-      const priorityIndex = tokens.indexOf('p_priority');
+      const priorityIndex = tokens.indexOf(`${key}_priority`);
 
       if (priorityIndex !== -1) {
         const priorityRule = rule[priorityIndex];
@@ -284,7 +284,7 @@ export class Model {
       }
     }
 
-    const priorityFlag = ast.tokens.indexOf('p_priority') !== -1;
+    const priorityFlag = ast.tokens.indexOf(`${ptype}_priority`) !== -1;
 
     if (priorityFlag) {
       rules.forEach((rule) => {
@@ -309,7 +309,7 @@ export class Model {
       return false;
     }
 
-    const priorityIndex = ast.tokens.indexOf('p_priority');
+    const priorityIndex = ast.tokens.indexOf(`${ptype}_priority`);
 
     if (priorityIndex !== -1) {
       if (oldRule[priorityIndex] === newRule[priorityIndex]) {


### PR DESCRIPTION
In a few places, it was still hardcoded to only look for the priority and effect of p, instead of using the ptype variable. Fixed so that it now has the same behaviour regardless of the order

fix #474