### PR TITLE
fix: issue with getAllNamedRoles function using wrong index in managementEnforcer.ts

### DIFF
--- a/src/managementEnforcer.ts
+++ b/src/managementEnforcer.ts
@@ -115,7 +115,7 @@ export class ManagementEnforcer extends InternalEnforcer {
    *         Duplicates are removed.
    */
   public async getAllNamedRoles(ptype: string): Promise<string[]> {
-    return this.model.getValuesForFieldInPolicy('g', ptype, 1);
+    return this.model.getValuesForFieldInPolicy('g', ptype, 0);
   }
 
   /**


### PR DESCRIPTION
Fix: [#476 ](https://github.com/casbin/node-casbin/issues/476)

Fix the issue in `getAllNamedRoles` function in `managementEnforcer.ts` where it is supposed to element from 0-index but is using 1-index

<img width="919" alt="Screenshot 2024-04-28 at 4 18 12 PM" src="https://github.com/casbin/node-casbin/assets/166595131/17ff2682-92d2-408a-b9e8-97148b7b3052">
