### PR TITLE
feat: use `import { Buffer } from 'buffer/'` to be compatible with Bun

### DIFF
--- a/src/persist/fileSystem.ts
+++ b/src/persist/fileSystem.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from 'buffer/';
 export interface FileSystem {
   readFileSync(path: string, encoding?: string): Buffer | string;
   writeFileSync(path: string, text: string, encoding?: string): void;

--- a/src/persist/fileSystem.ts
+++ b/src/persist/fileSystem.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer/';
 export interface FileSystem {
   readFileSync(path: string, encoding?: string): Buffer | string;
   writeFileSync(path: string, text: string, encoding?: string): void;

--- a/src/util/ip.ts
+++ b/src/util/ip.ts
@@ -26,7 +26,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import { Buffer } from 'buffer';
+import { Buffer } from 'buffer/';
 
 const ipv4Regex = /^(\d{1,3}\.){3,3}\d{1,3}$/;
 const ipv6Regex = /^(::)?(((\d{1,3}\.){3}(\d{1,3}){1})?([0-9a-f]){0,4}:{0,2}){1,8}(::)?$/i;


### PR DESCRIPTION
currently, the node-casbin is not compatible with Bun when running `bun build`
```
$ bun build src/index.ts --outdir ./build
28 | import { Buffer } from 'buffer';
              ^
error: No matching export in "node:buffer" for import "Buffer"
    at /.../node_modules/casbin/lib/esm/util/ip.js:28:10
error: script "build" exited with code 1
```
there is a open issue about buffer import with Bun: https://github.com/oven-sh/bun/issues/8683

according to `feross/buffer` [docs](https://github.com/feross/buffer?tab=readme-ov-file#usage)
> To require this module explicitly, use require('buffer/') which tells the node.js module lookup algorithm (also used by browserify) to use the npm module named buffer instead of the node.js core module named buffer!

by adding trailing slash, this will use the `feross/buffer` module explicitly which works with Bun.

