### PR TITLE
feat: add BracketAwareCsvParser to parse CSV file better

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@casbin/expression-eval": "^5.2.0",
     "await-lock": "^2.0.1",
     "buffer": "^6.0.3",
+    "csv-parse": "^5.5.6",
     "minimatch": "^7.4.2"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@casbin/expression-eval": "^5.2.0",
     "await-lock": "^2.0.1",
     "buffer": "^6.0.3",
-    "csv-parse": "^5.3.5",
     "minimatch": "^7.4.2"
   },
   "files": [

--- a/src/persist/fileAdapter.ts
+++ b/src/persist/fileAdapter.ts
@@ -34,11 +34,11 @@ export class FileAdapter implements Adapter {
   private async loadPolicyFile(model: Model, handler: (line: string, model: Model) => void): Promise<void> {
     const bodyBuf = await (this.fs ? this.fs : mustGetDefaultFileSystem()).readFileSync(this.filePath);
     const lines = bodyBuf.toString().split('\n');
-    lines.forEach((n: string, index: number) => {
-      if (!n) {
+    lines.forEach((line: string) => {
+      if (!line || line.trim().startsWith('#')) {
         return;
       }
-      handler(n, model);
+      handler(line, model);
     });
   }
 

--- a/src/persist/helper.ts
+++ b/src/persist/helper.ts
@@ -6,7 +6,7 @@ export class Helper {
       return;
     }
 
-    let tokens: string[] = [];
+    const tokens: string[] = [];
     let currentToken = '';
     let inQuotes = false;
     let bracketCount = 0;

--- a/src/persist/helper.ts
+++ b/src/persist/helper.ts
@@ -1,36 +1,47 @@
 import { Model } from '../model';
 import { parse } from 'csv-parse/sync';
 
-export class Helper {
-  public static loadPolicyLine(line: string, model: Model): void {
+export interface IPolicyParser {
+  parse(line: string): string[][] | null;
+}
+
+export class BasicCsvParser implements IPolicyParser {
+  parse(line: string): string[][] | null {
     if (!line || line.trimStart().charAt(0) === '#') {
-      return;
+      return null;
     }
 
-    const rawTokens = parse(line, {
+    return parse(line, {
       delimiter: ',',
       skip_empty_lines: true,
       trim: true,
       relax_quotes: true,
     });
+  }
+}
 
-    if (!rawTokens || rawTokens.length === 0 || !rawTokens[0]) {
-      return;
+export class BracketAwareCsvParser implements IPolicyParser {
+  private readonly baseParser: IPolicyParser;
+
+  constructor(baseParser: IPolicyParser = new BasicCsvParser()) {
+    this.baseParser = baseParser;
+  }
+
+  parse(line: string): string[][] | null {
+    const rawTokens = this.baseParser.parse(line);
+    if (!rawTokens || !rawTokens[0]) {
+      return null;
     }
 
-    const tokens: string[] = rawTokens[0];
-
+    const tokens = rawTokens[0];
     const processedTokens: string[] = [];
     let currentToken = '';
     let bracketCount = 0;
 
     for (const token of tokens) {
       for (const char of token) {
-        if (char === '(') {
-          bracketCount++;
-        } else if (char === ')') {
-          bracketCount--;
-        }
+        if (char === '(') bracketCount++;
+        else if (char === ')') bracketCount--;
       }
 
       currentToken += (currentToken ? ',' : '') + token;
@@ -45,11 +56,24 @@ export class Helper {
       throw new Error(`Unmatched brackets in policy line: ${line}`);
     }
 
-    if (processedTokens.length === 0) {
+    return processedTokens.length > 0 ? [processedTokens] : null;
+  }
+}
+
+export class PolicyLoader {
+  private readonly parser: IPolicyParser;
+
+  constructor(parser: IPolicyParser = new BracketAwareCsvParser()) {
+    this.parser = parser;
+  }
+
+  loadPolicyLine(line: string, model: Model): void {
+    const tokens = this.parser.parse(line);
+    if (!tokens || !tokens[0]) {
       return;
     }
 
-    let key = processedTokens[0].trim();
+    let key = tokens[0][0].trim();
     if (key.startsWith('"') && key.endsWith('"')) {
       key = key.slice(1, -1);
     }
@@ -65,7 +89,7 @@ export class Helper {
       return;
     }
 
-    const values = processedTokens.slice(1).map((v) => {
+    const values = tokens[0].slice(1).map((v) => {
       if (v.startsWith('"') && v.endsWith('"')) {
         v = v.slice(1, -1);
       }
@@ -73,5 +97,13 @@ export class Helper {
     });
 
     policy.policy.push(values);
+  }
+}
+
+export class Helper {
+  private static readonly policyLoader = new PolicyLoader();
+
+  public static loadPolicyLine(line: string, model: Model): void {
+    Helper.policyLoader.loadPolicyLine(line, model);
   }
 }

--- a/test/persist/helper.test.ts
+++ b/test/persist/helper.test.ts
@@ -45,7 +45,7 @@ m = r.sub == p.sub && r.obj == p.obj && r.act == p.act
     ['admin', '/', 'POST'],
     ['admin', '/', 'PUT'],
     ['admin', '/', 'DELETE'],
-    [' admin', '/ ', 'PATCH'],
+    ['admin', '/', 'PATCH'],
   ];
 
   testdata.forEach((n) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2282,11 +2282,6 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csv-parse@^5.3.5:
-  version "5.3.5"
-  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-5.3.5.tgz#9924bbba9f7056122f06b7af18edc1a7f022ce99"
-  integrity sha512-8O5KTIRtwmtD3+EVfW6BCgbwZqJbhTYsQZry12F1TP5RUp0sD9tp1UnCWic3n0mLOhzeocYaCZNYxOGSg3dmmQ==
-
 cz-conventional-changelog@3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz#6aef1f892d64113343d7e455529089ac9f20e477"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2282,6 +2282,11 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
+csv-parse@^5.5.6:
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-5.5.6.tgz#0d726d58a60416361358eec291a9f93abe0b6b1a"
+  integrity sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A==
+
 cz-conventional-changelog@3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz#6aef1f892d64113343d7e455529089ac9f20e477"


### PR DESCRIPTION
Part of: https://github.com/casbin/casbin-editor/issues/164

**Original Issue**
Limitations of CSV parser:
- The csv-parse library is mainly used for processing standard CSV format.
- Unable to handle complex policy expressions correctly
- Improper handling of commas and parentheses within quotation marks.
- Does not support nested expressions

**Improvement plan**
Custom parser:
```
const tokens: string[] = [];
let currentToken = '';
let inQuotes = false;
let bracketCount = 0;
```
- Can handle commas inside quotation marks
- Support nested parentheses
- Correctly handle escape characters

<img width="1502" alt="image" src="https://github.com/user-attachments/assets/d137546e-830c-4fa4-b627-b0c01131b155">
