### PR TITLE
feat: use empty array [] as reason for enforceEx()

### DIFF
--- a/src/coreEnforcer.ts
+++ b/src/coreEnforcer.ts
@@ -595,7 +595,7 @@ export class CoreEnforcer {
       if (explainIndex === -1) {
         return [res, []];
       }
-      return [res, p?.policy[explainIndex]];
+      return [res, p?.policy?.[explainIndex] || []];
     }
 
     return res;


### PR DESCRIPTION
Part of: https://github.com/casbin/casbin-editor/issues/193