### PR TITLE
feat(adapter): add lazyLoad parameter to initWithAdapter in newEnforcerWithClass

### DIFF
--- a/src/enforcer.ts
+++ b/src/enforcer.ts
@@ -501,7 +501,7 @@ export async function newEnforcerWithClass<T extends Enforcer>(enforcer: new () 
       if (typeof params[1] === 'string') {
         await e.initWithFile(params[0].toString(), params[1].toString());
       } else {
-        await e.initWithAdapter(params[0].toString(), params[1]);
+        await e.initWithAdapter(params[0].toString(), params[1], params[2] === true);
       }
     } else {
       if (typeof params[1] === 'string') {


### PR DESCRIPTION
The `newEnforcer` function is a key entry point for initializing an Enforcer instance in the `Casbin` library. This change introduces the ability to control lazy loading during the initialization process. Lazy loading allows users to defer the loading of policies until explicitly required, which can improve performance in scenarios where policy loading is not immediately necessary.

By adding a `lazyLoad` parameter to the `newEnforcer` initialization process, users gain more flexibility in managing their application's performance and resource usage. This is particularly useful in environments where policy data is large or where initialization speed is critical.

### Before the Change
Previously, the newEnforcer function would always load policies during initialization, regardless of whether they were needed immediately. For example:
```typescript
const e = await newEnforcer('path/to/model.conf', 'path/to/policy.csv');
```
This behavior could lead to unnecessary overhead in cases where the policies were not used right away.

### After the Change
With the lazyLoad parameter, users can now control when policies are loaded:
```typescript
// Initialize the enforcer with lazy loading enabled.
const e = await newEnforcer('path/to/model.conf', 'path/to/policy.csv', true);

// Policies are not loaded during initialization. They can be loaded explicitly later:
await e.loadPolicy();
```

### This approach provides the following benefits:

I**mproved Performance:** Policies are loaded only when needed, reducing initialization time.
**Resource Optimization**: Avoids loading large policy files unnecessarily.
**Flexibility**: Users can decide the best time to load policies based on their application's workflow.

**Scenario**: Frequent Dynamic Policy Creation with Large Policy Sets
In some applications, policies are not static but are dynamically created and updated frequently. For example, consider a multi-tenant system where each tenant has millions of policies that are stored in a database. Loading all these policies into memory at once can lead to significant performance bottlenecks, especially when the policies are not immediately required.

With the introduction of the lazyLoad parameter, users can now defer the loading of these large policy sets until they are explicitly needed. This is particularly useful in scenarios where:

**Dynamic Policy Creation**: Policies are being created or updated frequently, and loading them into memory every time would be inefficient.
**Large Policy Sets**: The number of policies is in the millions, making in-memory storage impractical due to memory constraints.
**Selective Policy Usage**: Only a subset of policies is required at any given time, and loading all policies upfront would waste resources.