### PR TITLE
fix: restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This project exists thanks to all the people who contribute.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=apache/casbin-node-casbin&type=Date)](https://star-history.com/#apache/casbin-node-casbin&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=apache/casbin-node-casbin&type=Date)](https://star-history.dera.page/#apache/casbin-node-casbin&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change switches it to a working provider so the chart renders again, matching other projects that already made the same switch.